### PR TITLE
Improved feature flags handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
 rand = "0.8.5"
 safetensors = "0.4.1"
 tokenizers = { version = "0.15.0", default-features = false }
-json-template = { path = "../json-template" }
+json-template = "0.9.5"
 
 [patch.crates-io]
 stable-diffusion = { path = "stable-diffusion"}

--- a/examples/generation/Cargo.toml
+++ b/examples/generation/Cargo.toml
@@ -13,4 +13,9 @@ keywords.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-stable-diffusion = { path = "../../stable-diffusion" }
+stable-diffusion = { path = "../../stable-diffusion"}
+
+[features]
+cuda = ["stable-diffusion/cuda"]
+metal = ["stable-diffusion/metal"]
+mkl = ["stable-diffusion/mkl"]

--- a/examples/generation/README.md
+++ b/examples/generation/README.md
@@ -1,0 +1,7 @@
+[![](https://dcbadge.vercel.app/api/server/rzaesS82MT)](https://discord.gg/rzaesS82MT)
+
+
+#  Run generation example
+```bash
+cargo run --release --package generation --bin generation --features <none|cuda|mkl|metal>
+```

--- a/stable-diffusion-cli/Cargo.toml
+++ b/stable-diffusion-cli/Cargo.toml
@@ -23,3 +23,8 @@ anyhow.workspace = true
 image.workspace = true
 clap.workspace = true
 candle.workspace = true
+
+[features]
+cuda = ["stable-diffusion/cuda"]
+metal = ["stable-diffusion/metal"]
+mkl = ["stable-diffusion/mkl"]

--- a/stable-diffusion/Cargo.toml
+++ b/stable-diffusion/Cargo.toml
@@ -12,7 +12,6 @@ authors.workspace = true
 keywords.workspace = true
 
 [features]
-default = ["cuda"]
 cuda = ["candle/cuda", "candle-nn/cuda", "candle-transformers/cuda", "dep:bindgen_cuda"]
 cudnn = ["candle/cudnn"]
 flash-attn = ["cuda", "candle-transformers/flash-attn", "dep:candle-flash-attn"]

--- a/stable-diffusion/README.md
+++ b/stable-diffusion/README.md
@@ -15,10 +15,10 @@ This is the Stable Diffusion core library.
 
 ## Backends
 
-* Cuda (default rust-feature)
+* CPU (default)
+* MKL
+* Cuda 
 * Metal
-* Onnx
-* CPU
 
 ## Examples
 


### PR DESCRIPTION
The PR introduces/modifies:
- Fix json-template dependency in the root Cargo.toml (build fix)
- Drop `cuda` as default feature for the library (fix docs.rs doc gen, fix stable-diffusion-cli build with `metal|mkl feature`)
- Add `cuda|mkl|metal` feature flags to `examples/generation, stable-diffusion-cli`
- Add automatic device selection to examples/generation based on feature flag
- Remove ONNX as backend in stable-diffusion Readme (from what I understand candle-onnx adds support to load onnx model files, not to run models on onnx runtime)